### PR TITLE
User Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1469,6 +1469,11 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
+    "atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
+    },
     "author-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
@@ -2545,6 +2550,90 @@
         }
       }
     },
+    "conf": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-9.0.0.tgz",
+      "integrity": "sha512-TGrWTD/tviifvdeoOZIYBmlceYJ0wq2lCzqbv7bT4KgostaCyyYe9uYWZdzPdhl4mROQXwMcc/iuAUsMTzf7pQ==",
+      "requires": {
+        "ajv": "^7.0.3",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.0",
+        "json-schema-typed": "^7.0.3",
+        "make-dir": "^3.1.0",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -2731,6 +2820,21 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
       "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
+    "debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "requires": {
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+        }
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -3647,6 +3751,22 @@
         "debug": "^2.2.0"
       }
     },
+    "electron-store": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-7.0.0.tgz",
+      "integrity": "sha512-ktoziul0TNETBxjZ1QLCPT9OGIQfDNb1AgvY29sqzca9c6H/ccV2NV+2d9epdlfo6dNZYI16BlHDVtFp9t3rvw==",
+      "requires": {
+        "conf": "^9.0.0",
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.612",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.612.tgz",
@@ -3762,8 +3882,7 @@
     "env-paths": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-      "dev": true
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -4132,8 +4251,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -7241,6 +7359,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8128,8 +8251,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -8712,7 +8834,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -9101,6 +9222,54 @@
         }
       }
     },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        }
+      }
+    },
     "plist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
@@ -9318,8 +9487,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -9616,6 +9784,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/require-dot-file/-/require-dot-file-0.4.0.tgz",
       "integrity": "sha1-tb9ValWJXC1ZDl3srUU1cXhQqek="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -11311,7 +11484,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "concurrently": "^5.3.0",
     "electron-reload": "^1.5.0",
     "electron-squirrel-startup": "^1.0.0",
+    "electron-store": "^7.0.0",
     "fomantic-ui": "^2.8.7",
     "jquery": "^3.5.1",
     "js-image-zoom": "^0.7.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,6 +9,7 @@
   import Detect from "./routes/Detect.svelte";
   import Review from "./routes/Review.svelte";
   import Documentation from "./routes/Documentation.svelte";
+  import Settings from "./routes/Settings.svelte";
 
   let page;
   let params;
@@ -27,6 +28,7 @@
     () => (page = Review)
   );
   router("/documentation", () => (page = Documentation));
+  router("/settings", () => (page = Settings));
   router("*", () => null); // TODO: why does this work?
   router.start();
   router.show("/");

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -7,18 +7,19 @@
     : false;
 </script>
 
-<style>
-</style>
-
 <div
   class="ui sidebar vertical menu left uncover visible"
-  style="background-color: #f8f9fa; border: 0; box-shadow: 1;">
+  style="background-color: #f8f9fa; border: 0; box-shadow: 1;"
+>
   <div style="padding: 1em; margin-bottom: 1em;">
     <h3>
       <img
         class="ui avatar image"
-        src={isDev ? path.join(process.cwd(), 'src', 'assets', 'icon.ico') : path.join(process.cwd(), 'resources', 'assets', 'icon.ico')}
-        alt="logo" />
+        src={isDev
+          ? path.join(process.cwd(), "src", "assets", "icon.ico")
+          : path.join(process.cwd(), "resources", "assets", "icon.ico")}
+        alt="logo"
+      />
       MegaDetector
       <span class="ui tiny grey text">v{version}</span>
     </h3>
@@ -32,5 +33,11 @@
   </a>
   <a class="item" href="/documentation">
     <h4><i class="book icon" /> Documentation</h4>
+  </a>
+  <a
+    class="item"
+    href="/settings"
+    style="position: absolute; bottom: 0; width: 100%;">
+    <h4><i class="cog icon" /> Settings</h4>
   </a>
 </div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, Menu } = require('electron')
 const path = require('path')
-
+const Store = require('electron-store')
 const isDev = process.env.APP_DEV ? process.env.APP_DEV.trim() == 'true' : false
 
 if (isDev) {
@@ -65,4 +65,6 @@ app.on('activate', () => {
 })
 
 // In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and import them here.
+
+// Initialise user settings store for use in the renderer process
+Store.initRenderer()

--- a/src/routes/Detect.svelte
+++ b/src/routes/Detect.svelte
@@ -6,6 +6,7 @@
   import router from "page";
   const path = require("path");
   const { dialog } = require("electron").remote;
+  import { settings } from "../userSettings.js";
 
   let modelSelected = false;
   let folderSelected = false;
@@ -43,7 +44,7 @@
     window.$(".ui.slider").slider({
       min: 0,
       max: 100,
-      start: 50,
+      start: settings.get("defaultConfidenceThreshold"),
       step: 5,
       smooth: false,
     });
@@ -76,9 +77,6 @@
     window.$(".ui.slider").slider("set value", 50);
   };
 </script>
-
-<style>
-</style>
 
 <Page title="Detect">
   <div class="column" style="width: 60%;">
@@ -114,12 +112,12 @@
               </div>
             </div>
             <div class="column">
-              <button
-                class="fluid ui primary button"
-                on:click={selectFolder}>Import Data</button>
-              <span
-                id="selectedDirectory"
-                class="ui small grey text">{selectedFolder ? selectedFolder : ''}</span>
+              <button class="fluid ui primary button" on:click={selectFolder}
+                >Import Data</button
+              >
+              <span id="selectedDirectory" class="ui small grey text"
+                >{selectedFolder ? selectedFolder : ""}</span
+              >
             </div>
           </div>
           <div class="row">
@@ -128,21 +126,25 @@
                 Confidence Threshold
               </h4>
               <div class="meta">
-                <span>Results below this level will be classified as empty</span>
+                <span>Results below this level will be classified as empty</span
+                >
               </div>
             </div>
             <div class="column">
               <div
                 class="ui small primary labeled ticked slider"
-                id="slider-1" />
+                id="slider-1"
+              />
             </div>
           </div>
           <div class="row">
             <div class="column">
               <h4 class="ui header" style="margin-bottom: 0;">Auto-sort</h4>
               <div class="meta">
-                <span>Skip human review and automatically put original images in
-                  categorised folders</span>
+                <span
+                  >Skip human review and automatically put original images in
+                  categorised folders</span
+                >
               </div>
             </div>
             <div class="column">
@@ -177,11 +179,10 @@
                 class="ui right labeled fluid icon green button"
                 on:click={() => {
                   processing = true;
-                  let inputPath = window.$('#selectedDirectory').text();
-                  let outputPath = path.join(inputPath, 'output');
-                  let conf = Number(window
-                        .$('.ui.slider')
-                        .slider('get value')) / 100.0;
+                  let inputPath = window.$("#selectedDirectory").text();
+                  let outputPath = path.join(inputPath, "output");
+                  let conf =
+                    Number(window.$(".ui.slider").slider("get value")) / 100.0;
                   backend.detect(inputPath, outputPath, conf, autosort);
                 }}>
                 <i class="play icon" />
@@ -192,7 +193,7 @@
                 id="stopButton"
                 class="ui right labeled fluid icon red button loading disabled"
                 on:click={() => {
-                  window.$('#stopModal').modal('show');
+                  window.$("#stopModal").modal("show");
                 }}>
                 <i class="stop icon" />
                 Stop
@@ -205,7 +206,8 @@
             <div
               class="ui green indicating progress"
               id="detectProgressBar"
-              style="margin-bottom: 0;">
+              style="margin-bottom: 0;"
+            >
               <div class="bar" style="height: 2.5em">
                 <div class="progress" />
               </div>
@@ -226,19 +228,17 @@
       <div
         class="ui button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
-        }}>
-        Back
-      </div>
+          window.$(".ui.modal").modal("hide");
+        }}
+      >Back</div>
       <div
         class="ui red button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
+          window.$(".ui.modal").modal("hide");
           backend.stopProcess();
           resetUI();
-        }}>
-        Stop
-      </div>
+        }}
+      >Stop</div>
     </div>
   </div>
   <div class="ui tiny modal" id="finishedModal">
@@ -251,8 +251,9 @@
             All images have been processed.
             {#if autosort}
               <div>
-                <span class="ui red text">(Some images may still be undergoing
-                  auto-sorting)</span>
+                <span class="ui red text"
+                  >(Some images may still be undergoing auto-sorting)</span
+                >
               </div>
             {/if}
           </div>
@@ -263,22 +264,27 @@
       <div
         class="ui button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
+          window.$(".ui.modal").modal("hide");
           resetUI();
-        }}>
-        Close
-      </div>
+        }}
+      >Close</div>
       {#if !autosort}
         <div
           class="ui green button"
           on:click={() => {
-            window.$('.ui.modal').modal('hide');
-            const resultsPath = path.join(selectedFolder, 'output', 'results.json');
+            window.$(".ui.modal").modal("hide");
+            const resultsPath = path.join(
+              selectedFolder,
+              "output",
+              "results.json"
+            );
             router.redirect(`/review/${resultsPath}`);
-          }}>
-          Human Review
-        </div>
+          }}
+        >Human Review</div>
       {/if}
     </div>
   </div>
 </Page>
+
+<style>
+</style>

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -217,7 +217,9 @@
         <div>
           <div class="left aligned floating ui label">
             <i class="images outline icon" />
-            {path.basename(currentImg.file)}
+            {settings.get("showFullImagePath")
+              ? currentImg.file
+              : path.basename(currentImg.file)}
             <div class="detail">
               {`${
                 currentImgIndex + 1 <= updatedResults.images.length

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -3,6 +3,7 @@
   import Page from "../components/Page.svelte";
   import ImageZoom from "js-image-zoom";
   import { backend } from "../bindings.js";
+  import { settings } from "../userSettings.js";
 
   const fs = require("fs");
   const path = require("path");
@@ -154,8 +155,10 @@
     } else {
       currentImg = updatedResults.images[currentImgIndex + 1];
       currentImgIndex += 1;
-      window.$(".ui.big.image, .horizontal.label").transition("stop");
-      window.$(".ui.big.image, .horizontal.label").transition("pulse");
+      if (settings.get("showImageTransition")) {
+        window.$(".ui.big.image, .horizontal.label").transition("stop");
+        window.$(".ui.big.image, .horizontal.label").transition("pulse");
+      }
     }
 
     if (numReviewedImgs <= updatedResults.images.length - 1) {
@@ -178,8 +181,10 @@
       currentImg = updatedResults.images[currentImgIndex - 1];
       currentImgIndex -= 1;
       updateMarkAs();
-      window.$(".ui.big.image, .horizontal.label").transition("stop");
-      window.$(".ui.big.image, .horizontal.label").transition("pulse");
+      if (settings.get("showImageTransition")) {
+        window.$(".ui.big.image, .horizontal.label").transition("stop");
+        window.$(".ui.big.image, .horizontal.label").transition("pulse");
+      }
     }
   };
 
@@ -191,9 +196,6 @@
     backend.move(savePath);
   };
 </script>
-
-<style>
-</style>
 
 <Page title="Review">
   <div class="column">
@@ -210,20 +212,26 @@
     {:else}
       <div
         class="ui fluid horizontal card"
-        style="width: 100%; margin-bottom: 0;">
+        style="width: 100%; margin-bottom: 0;"
+      >
         <div>
           <div class="left aligned floating ui label">
             <i class="images outline icon" />
             {path.basename(currentImg.file)}
             <div class="detail">
-              {`${currentImgIndex + 1 <= updatedResults.images.length ? currentImgIndex + 1 : currentImgIndex} / ${updatedResults.images.length}`}
+              {`${
+                currentImgIndex + 1 <= updatedResults.images.length
+                  ? currentImgIndex + 1
+                  : currentImgIndex
+              } / ${updatedResults.images.length}`}
             </div>
           </div>
           <div id="imageContainer">
             <img
               class="ui big image"
               src={currentImg.preview}
-              alt={currentImg.preview} />
+              alt={currentImg.preview}
+            />
           </div>
         </div>
         <div class="content">
@@ -239,7 +247,7 @@
                       class="ui compact icon primary button"
                       class:disabled={numReviewedImgs <= 0}
                       on:click={() => {
-                        window.$('#saveModal').modal('show');
+                        window.$("#saveModal").modal("show");
                       }}>
                       <i class="save icon" />
                       Save Progress
@@ -260,8 +268,9 @@
                   <div class="column">
                     <div
                       class="ui large horizontal label"
-                      class:green={categories[detection.category] === 'animal'}
-                      class:grey={categories[detection.category] !== 'animal'}>
+                      class:green={categories[detection.category] === "animal"}
+                      class:grey={categories[detection.category] !== "animal"}
+                    >
                       {categories[detection.category]}
                     </div>
                     {#if currentImg.edited}
@@ -272,9 +281,13 @@
                     <div
                       class="ui large horizontal label"
                       class:orange={detection.conf <= confThresh + colourSplit}
-                      class:olive={confThresh + colourSplit < detection.conf && detection.conf < 1 - colourSplit}
-                      class:green={detection.conf >= 1 - colourSplit}>
-                      {(Number(detection.conf) * 100).toPrecision(inputParams.conf_digits)}%
+                      class:olive={confThresh + colourSplit < detection.conf &&
+                        detection.conf < 1 - colourSplit}
+                      class:green={detection.conf >= 1 - colourSplit}
+                    >
+                      {(Number(detection.conf) * 100).toPrecision(
+                        inputParams.conf_digits
+                      )}%
                     </div>
                   </div>
                 </div>
@@ -306,15 +319,15 @@
             <button
               class="ui gray button"
               on:click={() => {
-                window.$('#markModal').modal('show');
+                window.$("#markModal").modal("show");
               }}>
               {#if currentImg && currentImg.edited}
                 Undo
               {:else}Mark as {markAs}{/if}
             </button>
-            <button
-              class="ui positive button"
-              on:click={nextImage}>Correct</button>
+            <button class="ui positive button" on:click={nextImage}
+              >Correct</button
+            >
           </div>
         </div>
       </div>
@@ -332,30 +345,28 @@
     <div class="content">
       <div class="description">
         {#if currentImg && currentImg.edited}
-          {#if markAs === 'animal'}
+          {#if markAs === "animal"}
             Bounding box and confidence data will be restored
-          {:else if markAs === 'empty'}Image will be labelled as empty{/if}
-        {:else if markAs === 'animal'}
+          {:else if markAs === "empty"}Image will be labelled as empty{/if}
+        {:else if markAs === "animal"}
           Confidence will be set to 100%. No bounding box data will exist.
-        {:else if markAs === 'empty'}Image will be labelled as empty{/if}
+        {:else if markAs === "empty"}Image will be labelled as empty{/if}
       </div>
     </div>
     <div class="actions">
       <div
         class="ui button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
-        }}>
-        Cancel
-      </div>
+          window.$(".ui.modal").modal("hide");
+        }}
+      >Cancel</div>
       <div
         class="ui primary button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
+          window.$(".ui.modal").modal("hide");
           updateResult(currentImg.file, markAs);
-        }}>
-        Yes
-      </div>
+        }}
+      >Yes</div>
     </div>
   </div>
   <div class="ui tiny modal" id="saveModal">
@@ -371,17 +382,15 @@
       <div
         class="ui button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
-        }}>
-        Cancel
-      </div>
+          window.$(".ui.modal").modal("hide");
+        }}
+      >Cancel</div>
       <div
         class="ui primary button"
         on:click={() => {
           saveUpdatedResults();
-        }}>
-        Save
-      </div>
+        }}
+      >Save</div>
     </div>
   </div>
   <div class="ui tiny modal" id="finishedModal">
@@ -400,17 +409,15 @@
       <div
         class="ui button"
         on:click={() => {
-          window.$('.ui.modal').modal('hide');
-        }}>
-        Close
-      </div>
+          window.$(".ui.modal").modal("hide");
+        }}
+      >Close</div>
       <div
         class="ui primary button"
         on:click={() => {
           saveUpdatedResults();
-        }}>
-        Save
-      </div>
+        }}
+      >Save</div>
     </div>
   </div>
 </Page>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -1,0 +1,114 @@
+<script>
+  import Page from "../components/Page.svelte";
+  import { onMount } from "svelte";
+  import Card from "../components/Card.svelte";
+  import { displayErrorToast, logToFile } from "../errors";
+
+  const fs = require("fs");
+  const path = require("path");
+
+  let settings = [];
+  let updatedSettings;
+
+  onMount(async () => {
+    window.$(".ui.checkbox").checkbox();
+
+    fs.readFile("settings.json", "utf8", (err, data) => {
+      if (err) {
+        displayErrorToast("error", err);
+        logToFile(err, "ERROR");
+      } else {
+        settings = JSON.parse(data);
+        updatedSettings = JSON.parse(data);
+      }
+    });
+  });
+
+  const saveSettings = () => {
+    let valid = true;
+    for (const [name, setting] of Object.entries(settings)) {
+      let newValue = setting.value;
+      if (setting.UI === "checkbox") {
+        newValue = window.$(`#${name}`).checkbox("is checked");
+      } else if (setting.UI === "input") {
+        newValue = window.$(`#${name}`).val();
+        if (setting.type === "float") {
+          newValue = parseFloat(newValue);
+        } else if (setting.type === "integer") {
+          newValue = parseInt(newValue, 10);
+        }
+        if (setting.type !== "string") {
+          if (
+            isNaN(newValue) ||
+            newValue < setting.validation.min ||
+            newValue > setting.validation.max
+          ) {
+            window.$(`#${name}ParentDiv`).addClass("error");
+            valid = false;
+            break;
+          } else {
+            window.$(`#${name}ParentDiv`).removeClass("error");
+          }
+        }
+      }
+      updatedSettings[name].value = newValue;
+    }
+    if (valid) {
+      fs.writeFileSync(
+        "settings.json",
+        JSON.stringify(updatedSettings, null, 4)
+      );
+    }
+    console.log(updatedSettings);
+  };
+</script>
+
+<Page title="Settings">
+  <div class="column" style="width: 80%;">
+    <Card>
+      <div class="ui grid">
+        {#each Object.entries(settings) as [s, setting]}
+          <div class="four column row">
+            <div class="eight wide left floated column">
+              <h4 class="ui header" style="margin-bottom: 0;">
+                {setting.displayName}
+              </h4>
+              <div class="meta">
+                <span>{setting.description}</span>
+              </div>
+            </div>
+            <div class="eight wide right floated right aligned column">
+              {#if setting.UI === "checkbox"}
+                <div
+                  id={s}
+                  class="ui toggle checkbox"
+                  class:checked={setting.value ? true : null}
+                >
+                  <input
+                    type="checkbox"
+                    name={s}
+                    checked={setting.value ? true : null}
+                  />
+                  <label for={s} />
+                </div>
+              {:else if setting.UI === "input"}
+                <div id={`${s}ParentDiv`} class="ui right labeled input">
+                  <input id={s} type="text" value={setting.value} />
+                  <div class="ui basic label">%</div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        {:else}
+          <p>loading...</p>
+        {/each}
+      </div>
+    </Card>
+    <button class="ui positive right floated button" on:click={saveSettings}
+      >Save</button
+    >
+  </div>
+</Page>
+
+<style>
+</style>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -48,7 +48,7 @@
             </h4>
             <div class="meta">
               <span
-                >"Whether to render the animation when cycling through images</span
+                >Whether to render the animation when cycling through images</span
               >
             </div>
           </div>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -2,57 +2,38 @@
   import Page from "../components/Page.svelte";
   import { onMount } from "svelte";
   import Card from "../components/Card.svelte";
-  const Store = require("electron-store");
+  import { settings } from "../userSettings.js";
 
-  const schema = {
-    showImageTransition: {
-      type: "boolean",
-      default: false,
-    },
-    showFullImagePath: {
-      type: "boolean",
-      default: false,
-    },
-    defaultConfidenceThreshold: {
-      type: "number",
-      minimum: 0,
-      maximum: 100,
-      default: 50,
-    },
-  };
-
-  const store = new Store({ schema });
-
-  let settings = {};
+  let settingsCopy = {};
 
   onMount(async () => {
-    settings = store.store;
+    settingsCopy = settings.store;
 
     // initialise inputs
     window.$("#showImageTransition").checkbox({
       onChange: () => {
-        settings.showImageTransition = !settings.showImageTransition;
+        settingsCopy.showImageTransition = !settingsCopy.showImageTransition;
       },
     });
     window.$("#showFullImagePath").checkbox({
       onChange: () => {
-        settings.showFullImagePath = !settings.showFullImagePath;
+        settingsCopy.showFullImagePath = !settingsCopy.showFullImagePath;
       },
     });
     window.$(".ui.slider").slider({
       min: 0,
       max: 100,
-      start: store.get("defaultConfidenceThreshold"),
+      start: settings.get("defaultConfidenceThreshold"),
       step: 5,
       smooth: false,
       onChange: (v) => {
-        settings.defaultConfidenceThreshold = v;
+        settingsCopy.defaultConfidenceThreshold = v;
       },
     });
   });
 
   const saveSettings = () => {
-    store.store = settings;
+    settings.store = settingsCopy;
   };
 </script>
 
@@ -75,12 +56,12 @@
             <div
               id="showImageTransition"
               class="ui toggle checkbox"
-              class:checked={settings.showImageTransition ? true : null}
+              class:checked={settingsCopy.showImageTransition ? true : null}
             >
               <input
                 type="checkbox"
                 name="showImageTransition"
-                checked={settings.showImageTransition ? true : null}
+                checked={settingsCopy.showImageTransition ? true : null}
               />
               <label for="showImageTransition" />
             </div>
@@ -100,12 +81,12 @@
             <div
               id="showFullImagePath"
               class="ui toggle checkbox"
-              class:checked={settings.showFullImagePath ? true : null}
+              class:checked={settingsCopy.showFullImagePath ? true : null}
             >
               <input
                 type="checkbox"
                 name="showFullImagePath"
-                checked={settings.showFullImagePath ? true : null}
+                checked={settingsCopy.showFullImagePath ? true : null}
               />
               <label for="showFullImagePath" />
             </div>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -33,7 +33,11 @@
   });
 
   const saveSettings = () => {
+    window.$("#saveButton").addClass("loading disabled");
     settings.store = settingsCopy;
+    setTimeout(() => {
+      window.$("#saveButton").removeClass("loading disabled");
+    }, 500);
   };
 </script>
 
@@ -111,9 +115,11 @@
         </div>
       </div>
     </Card>
-    <button class="ui positive right floated button" on:click={saveSettings}
-      >Save</button
-    >
+    <button
+      id="saveButton"
+      class="ui positive right floated button"
+      on:click={saveSettings}>Save
+    </button>
   </div>
 </Page>
 

--- a/src/userSettings.js
+++ b/src/userSettings.js
@@ -3,7 +3,7 @@ const Store = require('electron-store')
 const schema = {
   showImageTransition: {
     type: 'boolean',
-    default: false,
+    default: true,
   },
   showFullImagePath: {
     type: 'boolean',

--- a/src/userSettings.js
+++ b/src/userSettings.js
@@ -1,0 +1,20 @@
+const Store = require('electron-store')
+
+const schema = {
+  showImageTransition: {
+    type: 'boolean',
+    default: false,
+  },
+  showFullImagePath: {
+    type: 'boolean',
+    default: false,
+  },
+  defaultConfidenceThreshold: {
+    type: 'number',
+    minimum: 0,
+    maximum: 100,
+    default: 50,
+  },
+}
+
+export const settings = new Store({ schema })


### PR DESCRIPTION
This PR introduces the Settings panel which allows users to customise minor behaviours in the app. 
Right now, you can:

- toggle the image animation on or off (some users complained that it slows them down too much)
- toggle the full image path (the little label usually displays just the filename but it is sometimes useful to have the full path)
- set the default confidence threshold

This introduces a new dependecy, `electron-store` which is a mature package that stores settings in a .json file in the appropriate OS path. This solution comes with various advantages:

- can easily extend the settings panel with more settings
- can provide a schema for validation
- the file doesn't get overwritten if the user installs a new version of the app
- the package handles migrations in case the config schema changes
- I assume it's also OS agnostic but that doesn't matter that much for us at the moment

Fixes #17 