### PR TITLE
Improved handling for multiple detections

### DIFF
--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -177,7 +177,6 @@
             category: "1",
             conf: 1,
             bbox: [],
-            manMade: true,
           },
         ];
       }

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -109,6 +109,7 @@
 
   const markAsAnimal = (img) => {
     img.markedAsAnimal = true;
+    currentImg.reviewed = true;
   };
 
   const undoMarkAsAnimal = (img) => {
@@ -118,6 +119,7 @@
 
   const markForDeletion = (d) => {
     d.deleted = true;
+    currentImg.reviewed = true;
   };
 
   const undoMarkForDeletion = (d) => {
@@ -126,9 +128,7 @@
 
   const nextImage = () => {
     currentImg.reviewed = true;
-    if (currentImgIndex + 1 >= updatedResults.images.length) {
-      forceUpdate();
-    } else {
+    if (currentImgIndex < updatedResults.images.length - 1) {
       currentImg = updatedResults.images[currentImgIndex + 1];
       currentImgIndex += 1;
       if (settings.get("showImageTransition")) {
@@ -137,9 +137,8 @@
       }
     }
 
-    if (numReviewedImgs <= updatedResults.images.length - 1) {
-      numReviewedImgs += 1;
-    }
+    numReviewedImgs = updatedResults.images.filter((i) => i.reviewed === true)
+      .length;
 
     // update percent
     window
@@ -366,12 +365,15 @@
             </button>
             <button
               class="ui right floated compact icon button"
-              class:disabled={currentImgIndex ===
-                updatedResults.images.length - 1}
               on:click={nextImage}
             >
-              Next
-              <i class="arrow right icon" />
+              {#if currentImgIndex === updatedResults.images.length - 1}
+                Finish
+                <i class="check icon" />
+              {:else}
+                Next
+                <i class="arrow right icon" />
+              {/if}
             </button>
           </div>
         </div>

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -66,19 +66,6 @@
     d.deleted = false;
   };
 
-  // TODO: refactor
-  const createDetection = (img) => {
-    img.detections = [
-      {
-        label: "animal",
-        category: "1",
-        conf: 1,
-        bbox: [],
-        manMade: true,
-      },
-    ];
-  };
-
   const deleteZoom = () => {
     // this is pretty hacky but I can't find a proper way to use the kill method for ImageZoom
     window.$(".js-image-zoom__zoomed-area").remove();
@@ -180,9 +167,36 @@
     }
   };
 
+  const processUpdatedResults = () => {
+    for (const img of updatedResults.images) {
+      // create detections
+      if (img.markedAsAnimal) {
+        img.detections = [
+          {
+            label: "animal",
+            category: "1",
+            conf: 1,
+            bbox: [],
+            manMade: true,
+          },
+        ];
+      }
+
+      // delete detections
+      for (let [d, det] of img.detections.entries()) {
+        if (det.deleted) {
+          img.detections.splice(d, 1);
+        }
+      }
+    }
+  };
+
   const saveUpdatedResults = () => {
+    processUpdatedResults();
+
     window.$(".ui.primary.button").addClass("loading");
     let data = JSON.stringify(updatedResults, null, 4);
+
     let savePath = path.join(path.dirname(resultsPath), "updated_results.json");
     fs.writeFileSync(savePath, data);
     backend.move(savePath);

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -22,14 +22,13 @@
   let numReviewedImgs = 0;
   let resultsPath;
 
-  let options = {
-    width: 600,
-    height: 450,
-    zoomWidth: 522,
-    offset: { vertical: 0, horizontal: 5 },
-    zoomPosition: "right",
-    zoomStyle: "z-index: 1000; position: absolute; border-radius: 3px",
-  };
+  onMount(async () => {
+    window.$(".ui.modal").modal();
+    if (params && params.resultsPath) {
+      resultsPath = params.resultsPath;
+      readResults();
+    }
+  });
 
   onDestroy(() => {
     if (backend.childProcess || numReviewedImgs > 0) {
@@ -43,34 +42,20 @@
     }
   });
 
-  const forceUpdate = () => {
-    // pretend to update image so Svelte can pick up the changes
-    currentImg = updatedResults.images[currentImgIndex];
-  };
-
-  const markAsAnimal = (img) => {
-    img.markedAsAnimal = true;
-    //forceUpdate();
-  };
-
-  const undoMarkAsAnimal = (img) => {
-    img.markedAsAnimal = false;
-    forceUpdate();
-  };
-
-  const markForDeletion = (d) => {
-    d.deleted = true;
-  };
-
-  const undoMarkForDeletion = (d) => {
-    d.deleted = false;
-  };
-
-  const deleteZoom = () => {
-    // this is pretty hacky but I can't find a proper way to use the kill method for ImageZoom
+  afterUpdate(() => {
+    // Delete zoom instance. This is pretty hacky but I can't find a proper way to use the kill method for ImageZoom
     window.$(".js-image-zoom__zoomed-area").remove();
     window.$(".js-image-zoom__zoomed-image").remove();
-  };
+
+    new ImageZoom(document.getElementById("imageContainer"), {
+      width: 600,
+      height: 450,
+      zoomWidth: 522,
+      offset: { vertical: 0, horizontal: 5 },
+      zoomPosition: "right",
+      zoomStyle: "z-index: 1000; position: absolute; border-radius: 3px",
+    });
+  });
 
   const selectFile = () => {
     dialog
@@ -117,18 +102,27 @@
     });
   };
 
-  onMount(async () => {
-    window.$(".ui.modal").modal();
-    if (params && params.resultsPath) {
-      resultsPath = params.resultsPath;
-      readResults();
-    }
-  });
+  const forceUpdate = () => {
+    // pretend to update image so Svelte can pick up the changes
+    currentImg = updatedResults.images[currentImgIndex];
+  };
 
-  afterUpdate(() => {
-    deleteZoom();
-    new ImageZoom(document.getElementById("imageContainer"), options);
-  });
+  const markAsAnimal = (img) => {
+    img.markedAsAnimal = true;
+  };
+
+  const undoMarkAsAnimal = (img) => {
+    img.markedAsAnimal = false;
+    forceUpdate();
+  };
+
+  const markForDeletion = (d) => {
+    d.deleted = true;
+  };
+
+  const undoMarkForDeletion = (d) => {
+    d.deleted = false;
+  };
 
   const nextImage = () => {
     currentImg.reviewed = true;

--- a/src/routes/Review.svelte
+++ b/src/routes/Review.svelte
@@ -50,7 +50,7 @@
 
   const markAsAnimal = (img) => {
     img.markedAsAnimal = true;
-    forceUpdate();
+    //forceUpdate();
   };
 
   const undoMarkAsAnimal = (img) => {
@@ -242,7 +242,8 @@
                       class:disabled={numReviewedImgs <= 0}
                       on:click={() => {
                         window.$("#saveModal").modal("show");
-                      }}>
+                      }}
+                    >
                       <i class="save icon" />
                       Save Progress
                     </button>
@@ -286,7 +287,8 @@
                         on:click={() => {
                           undoMarkForDeletion(detection);
                           forceUpdate();
-                        }}>
+                        }}
+                      >
                         <i class="undo icon" />
                       </button>
                     {:else}
@@ -296,7 +298,11 @@
                         on:click={() => {
                           markForDeletion(detection);
                           forceUpdate();
-                        }}>
+                          if (currentImg.detections.length === 1) {
+                            nextImage();
+                          }
+                        }}
+                      >
                         <i class="times icon" />
                       </button>
                     {/if}
@@ -320,7 +326,8 @@
                         style="padding: 6px;"
                         on:click={() => {
                           undoMarkAsAnimal(currentImg);
-                        }}>
+                        }}
+                      >
                         <i class="undo icon" />
                       </button>
                     {:else}
@@ -329,7 +336,9 @@
                         style="padding: 6px;"
                         on:click={() => {
                           markAsAnimal(currentImg);
-                        }}>
+                          nextImage();
+                        }}
+                      >
                         <i class="paw icon" />
                       </button>
                     {/if}
@@ -343,7 +352,8 @@
             <button
               class="ui left floated compact icon button"
               class:disabled={currentImgIndex === 0}
-              on:click={prevImage}>
+              on:click={prevImage}
+            >
               <i class="arrow left icon" />
               Prev
             </button>
@@ -351,7 +361,8 @@
               class="ui right floated compact icon button"
               class:disabled={currentImgIndex ===
                 updatedResults.images.length - 1}
-              on:click={nextImage}>
+              on:click={nextImage}
+            >
               Next
               <i class="arrow right icon" />
             </button>
@@ -378,13 +389,17 @@
         on:click={() => {
           window.$(".ui.modal").modal("hide");
         }}
-      >Cancel</div>
+      >
+        Cancel
+      </div>
       <div
         class="ui primary button"
         on:click={() => {
           saveUpdatedResults();
         }}
-      >Save</div>
+      >
+        Save
+      </div>
     </div>
   </div>
   <div class="ui tiny modal" id="finishedModal">
@@ -405,13 +420,17 @@
         on:click={() => {
           window.$(".ui.modal").modal("hide");
         }}
-      >Close</div>
+      >
+        Close
+      </div>
       <div
         class="ui primary button"
         on:click={() => {
           saveUpdatedResults();
         }}
-      >Save</div>
+      >
+        Save
+      </div>
     </div>
   </div>
 </Page>


### PR DESCRIPTION
This PR introduces some changes to the Review UI/UX.

Before users were unable to remove incorrect detections when an image had more than one detection. Pressing the correct button was unintuitive in these cases.

The UI has been changed:

- Mark As X button removed
- Correct button removed
- Added Next button 
- Added buttons to selectively approve/remove detections
    - When there is only 1 detection (or it's an empty image) the these buttons automatically take you to the next image too
    - When there are multiple detections, you have to press the Next button to advance

Fixes #12 
Fixes #20  